### PR TITLE
Refactoring:

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,18 @@
+var gulp = require('gulp');
+var mocha = require('gulp-mocha');
+var expect = require('chai').expect;
+
+
+gulp.task('default', function () {
+    global.expect = expect;
+
+    return gulp.src('test/traceur_command_builder_test.js', {read: false})
+        .pipe(mocha(
+            {
+                reporter: 'nyan',
+                globals: {
+                    expect: expect
+                }
+            }
+        ));
+});

--- a/index.js
+++ b/index.js
@@ -5,83 +5,43 @@
 var map   = require('map-stream'),
     gutil   = require('gulp-util'),
     exec    = require('child_process').exec,
-    fs      = require('fs');
-
-//function to build the commandline arguments part out of the user params and the params the command line gives. This should reduce boilerplate
-function build_commandline_opts(user_opts) {
-
-    var commandline_opts = {
-        modules: 'inline',
-        'source-maps': null
-    };
-
-    function build_param_string(key) {
-        var val = user_opts[key];
-        if (val) {
-            return '--' + key + '=' + val;
-        }
-        var default_val = commandline_opts[key];
-        if (default_val !== null) {
-            gutil.log(gutil.colors.yellow('\n       *** Debug : Traceur "'+key+'" not defined. Defaulting to "'+default_val+'"  ***\n'));
-            return '--' + key + '=' + default_val;
-        }
-        return '';
-    }
-
-    return Object.keys(commandline_opts).map(build_param_string).join(" ");
-
-}
+    fs      = require('fs'),
+    build_commandline = require('./lib/traceur_command_builder');
 
 module.exports = function(traceurcmd, opt) {
 
     // Assign default options if one is not supplied
     opt = opt || {};
-    opt.out =  opt.out     || false;
-    opt.debug =   opt.debug   || false;
+    var debug =   opt.debug   || false;
+    delete opt.debug;
+    var clear = opt.clear;
+    delete opt.clear;
 
-    // check for traceur command
-    if (!traceurcmd) {
 
-        fs.exists('/usr/local/bin/traceur', function(exists) {
-            if (!exists) {
-                gutil.log(gutil.colors.red('[ERROR]', "Traceur command not provided and default of /usr/local/bin/traceur does not exist on system"));
-            }
-        });
-
-        traceurcmd = '/usr/local/bin/traceur';
-
-        gutil.log(gutil.colors.blue('[NOTICE]', "Traceur command not provided, defaulting to /usr/local/bin/traceur"));
-
-    }
 
     return map( function(file, cb) {
+        var module_opts = {
+            clear: clear,
+            file: file,
+            traceurcmd: traceurcmd
+        };
 
-        var cmd = opt.clear ? 'clear && ' + traceurcmd : traceurcmd;
-
-        var command_options_part = build_commandline_opts(opt);
-        cmd += ' ' + command_options_part + ' ';
+        var cmd = build_commandline(opt, module_opts);
 
 
-        // add out option
-        if (!opt.out) {
-            gutil.log(gutil.colors.red('\n       *** Error : "out" not provided!  ***\n'));
-            // TODO : throw error here
-        }
 
-        cmd += ' --out ' + opt.out;
 
-        // add file path
-        cmd += ' ' + file.path;
+
 
         // print out debug details
-        if (opt.debug) {
+        if (debug) {
             gutil.log(gutil.colors.yellow('\n       *** Debug : Command - ' + cmd  + ' ***\n'));
         }
 
         exec(cmd, function(error, stdout, stderr) {
             // call user callback if ano error occurs
             if (error) {
-                if (opt.debug) {
+                if (debug) {
                     gutil.log(error);
                 }
                 cb(error, file);

--- a/lib/traceur_command_builder.js
+++ b/lib/traceur_command_builder.js
@@ -1,0 +1,73 @@
+var fs      = require('fs'),
+    gutil   = require('gulp-util');
+
+module.exports = exports = build_commandline;
+
+
+
+
+
+function build_commandline(traceur_command_opts, module_opts) {
+    var traceurcmd = get_traceur_command(module_opts.traceurcmd);
+    var commandline_string = build_commandline_opts(traceur_command_opts);
+    var clear_string =  module_opts.clear ? 'clear && ' : '';
+    var command = clear_string + traceurcmd + " " + commandline_string + " "+ module_opts.file.path;
+    return command;
+}
+
+
+function get_traceur_command(traceurcmd) {
+    if (!traceurcmd) {
+        fs.exists('/usr/local/bin/traceur', function(exists) {
+            if (!exists) {
+                gutil.log(gutil.colors.red('[ERROR]', "Traceur command not provided and default of /usr/local/bin/traceur does not exist on system"));
+            }
+        });
+
+        traceurcmd = '/usr/local/bin/traceur';
+
+        gutil.log(gutil.colors.blue('[NOTICE]', "Traceur command not provided, defaulting to /usr/local/bin/traceur"));
+
+    }
+    return traceurcmd;
+}
+
+//function to build the commandline arguments part out of the user params and the params the command line gives. This should reduce boilerplate
+function build_commandline_opts(user_opts) {
+
+    var default_opts = {
+        modules: 'inline'
+    };
+
+    function build_opt_string(key, val) {
+        if(val === true) {
+            return '--'+key;
+        }
+        return '--' + key + '=' + val;
+    }
+
+    function build_user_opt_string(key) {
+        var val = user_opts[key];
+        var opt_string = build_opt_string(key, val);
+        return opt_string;
+    }
+
+    function build_default_opt_string(key) {
+        if(!(key in user_opts)) {
+            var default_val = default_opts[key];
+            gutil.log(gutil.colors.yellow('\n       *** Debug : Traceur "'+key+'" not defined. Defaulting to "'+default_val+'"  ***\n'));
+            return build_opt_string(key, default_val)
+        }
+        return '';
+    }
+
+    // add out option
+    if (!user_opts.out) {
+        gutil.log(gutil.colors.red('\n       *** Error : "out" not provided!  ***\n'));
+        // TODO : throw error here
+    }
+
+    var user_opts_string =  Object.keys(user_opts).map(build_user_opt_string).join(" ");
+    var default_opts_string = Object.keys(default_opts).map(build_default_opt_string).join(" ");
+    return user_opts_string + " "+ default_opts_string;
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "gulp-util": "~3.0.0"
   },
   "devDependencies": {
-    "jshint": "~2.5.4",
-    "mocha": "~1.21.4",
-    "should": "~4.0.4",
-    "gulp-mocha": "~1.0.0",
-    "gulp": "~3.8.7"
+    "chai": "^1.10.0",
+    "gulp": "^3.8.10",
+    "gulp-mocha": "^2.0.0"
   },
   "scripts": {
     "test": "mocha --reporter spec && jshint ./*.js && jshint ./test/*.js"
@@ -24,8 +22,8 @@
   },
   "keywords": [
     "gulpplugin",
-    "gulp-traceur-cmdline", 
-    "traceur", 
+    "gulp-traceur-cmdline",
+    "traceur",
     "javascript",
     "es5",
     "es6",

--- a/test/traceur_command_builder_test.js
+++ b/test/traceur_command_builder_test.js
@@ -1,0 +1,54 @@
+var build_commandline = require('../lib/traceur_command_builder');
+
+var fake = {path: 'a.js'};
+
+
+
+describe("CommandBuilder", function() {
+    describe("command line command", function() {
+        it("check default command line command", function () {
+            var command = build_commandline({}, {file: fake});
+            expect(command).to.have.string('/usr/local/bin/traceur');
+        });
+        it("check command line command", function () {
+            var command = build_commandline({}, {file: fake, traceurcmd: 'traceur'});
+            expect(command).not.to.have.string('/usr/local/bin/traceur');
+            expect(command).to.have.string('traceur');
+        });
+    });
+
+        describe("modules option", function() {
+            it("default module option", function(){
+                var command = build_commandline({},{file: fake, traceurcmd: 'traceur'});
+                expect(command).to.have.string('--modules=inline');
+            });
+
+            it("custom module option", function(){
+                var command = build_commandline({modules: 'register'},{file: fake, traceurcmd: 'traceur'});
+                expect(command).to.have.string('--modules=register');
+            })
+        });
+
+        describe("file param", function() {
+           it("file param", function(){
+               var command = build_commandline({},{file: fake, traceurcmd: 'traceur'});
+               expect(command).to.have.string('a.js');
+           });
+        });
+
+
+        describe("clear param", function() {
+            it("with clear", function(){
+                var command = build_commandline({},{file: fake, traceurcmd: 'traceur', clear:true});
+                expect(command).to.have.string('clear &&');
+            });
+
+            it("without clear", function(){
+                var command = build_commandline({},{file: fake, traceurcmd: 'traceur'});
+                expect(command).not.to.have.string('clear &&');
+            });
+        });
+
+
+}
+);


### PR DESCRIPTION
closes: #4
The following changes were made:
- lib -added module which builds the command line executed by index.js
- test - added mocha unit tests with the chai library
- gulpfile.js - added gulpfile which runs the tests
- index.js calling now the lib file
- package.json - made little clean up of the devdependencies. Added chai library

Another important issue i fixed was that now the user can add all the command line arguments as he wants and we don't stand in his way. I added the default_opts hash so that our default values may be different from the commandline opts as the modules default option is for us inline and for them register
