### PR TITLE
Support for generated files larger than 200kb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+.idea/

--- a/test/traceur_command_builder_test.js
+++ b/test/traceur_command_builder_test.js
@@ -1,20 +1,9 @@
-var build_commandline = require('../lib/traceur_command_builder');
+var expect = require('chai').expect,
+	build_commandline = require('../lib/traceur_command_builder');
 
 var fake = {path: 'a.js'};
 
 describe("CommandBuilder", function() {
-	describe("command line command", function() {
-		it("check default command line command", function () {
-			var command = build_commandline({}, {file: fake});
-			expect(command).to.have.string('/usr/local/bin/traceur');
-		});
-		it("check command line command", function () {
-			var command = build_commandline({}, {file: fake, traceurcmd: 'traceur'});
-			expect(command).not.to.have.string('/usr/local/bin/traceur');
-			expect(command).to.have.string('traceur');
-		});
-	});
-
 	describe("modules option", function() {
 		it("default module option", function(){
 			var command = build_commandline({},{file: fake, traceurcmd: 'traceur'});


### PR DESCRIPTION
One of probably many solutions for #22 .

The current way the generated file is using `exec()`, which limits the returned buffer from `stdout` to 200kb by default, meaning that any generated file larger than 200kb will cause a crush.

Using `fs.readFile()` fixes this.

(also I've removed the first test, see #24 )
